### PR TITLE
Add Styles As A Map PropType

### DIFF
--- a/src/creators/GoogleMapHolder.js
+++ b/src/creators/GoogleMapHolder.js
@@ -30,6 +30,7 @@ export const mapControlledPropTypes = {
   streetView: PropTypes.any,
   tilt: PropTypes.number,
   zoom: PropTypes.number,
+  styles: PropTypes.array,
 };
 
 export const mapDefaultPropTypes = defaultPropsCreator(mapControlledPropTypes);


### PR DESCRIPTION
Can we add styles a proptype that is allowed in the mapOptions object? It is a valid supported key.

Sample code:

``` javascript
var mapOptions = {
    // How zoomed in you want the map to start at (always required)
    zoom: 11,

    // The latitude and longitude to center the map (always required)
    center: new google.maps.LatLng(40.6700, -73.9400), // New York

    // How you would like to style the map. 
    // This is where you would paste any style found on Snazzy Maps.
    styles: [{"featureType":"all","elementType":"all","stylers":[{"invert_lightness":true},{"saturation":10},{"lightness":30},{"gamma":0.5},{"hue":"#435158"}]}]
};

// Get the HTML DOM element that will contain your map 
// We are using a div with id="map" seen below in the <body>
var mapElement = document.getElementById('map');

// Create the Google Map using our element and options defined above
var map = new google.maps.Map(mapElement, mapOptions);
```

Sample Image Showing Working Styles:
<img width="933" alt="screen shot 2016-05-24 at 5 20 42 pm" src="https://cloud.githubusercontent.com/assets/246603/15524154/9a15bb8e-21d4-11e6-8f07-44ecdb76a508.png">
